### PR TITLE
Add list choosing in case of multiple file matches

### DIFF
--- a/doc/marvim.txt
+++ b/doc/marvim.txt
@@ -156,6 +156,10 @@ TIPS                                                              *marvim-tips*
 * share your marvim marco stores with each other and also with the
   central repository at the plugin in github.
 
+* You can use wildcards for macros names (when searching for them). It can
+  let you type only part of the macro file name. For info on the wildcards
+  See |wildcards| for the use of special characters.
+
 ===============================================================================
 CHANGELOG                                                    *marvim-changelog*
 

--- a/doc/tags
+++ b/doc/tags
@@ -9,6 +9,7 @@
 'g:marvim_use_store_key'	marvim.txt	/*'g:marvim_use_store_key'*
 'marvim'	marvim.txt	/*'marvim'*
 loaded_marvim	marvim.txt	/*loaded_marvim*
+'marvim'	marvim.txt	/*'marvim'*
 marvim-call-macro	marvim.txt	/*marvim-call-macro*
 marvim-changelog	marvim.txt	/*marvim-changelog*
 marvim-contents	marvim.txt	/*marvim-contents*

--- a/readme.md
+++ b/readme.md
@@ -126,6 +126,10 @@ source $HOME/marvim.vim   " omit if marvim.vim is in the plugin dir
 * share your marvim marco stores with each other and also with the
   central repository at the plugin in github.
 
+* You can use wildcards for macros names (when searching for them). It can
+  let you type only part of the macro file name. For info on the wildcards
+  See |wildcards| for the use of special characters.
+
 ## Bugs, Patches, Help and Suggestions
 If you find any bugs, have new patches or need some help, please open an issue
 at the [repository at github](https://github.com/chamindra/marvim) or send an


### PR DESCRIPTION
@chamindra 
Added a new option to choose between macro files in case there are more
than one match for the glob search. Until now, the behavior in this case
was unexpected, since glob returned all the values one after the other,
and the behavior was different between computers.
Now, glob would always return a list with all the matching values. In
case there would be more than one match in this list, the user would be
asked to choose which file he wants to run. The regular behavior of the
plugin (when there is only one result) stays the same.

Now, the use of wildcards in the search can be used more wildly, since
it would let the user choose the wanted macro in case of wildcard that
matches more than one file. So, I added a documentation about it as
a tip, both in the readme file and in the plugin doc directory.

This commit solves issue #6