### PR TITLE
Fix macro ending with '^M'

### DIFF
--- a/autoload/marvim.vim
+++ b/autoload/marvim.vim
@@ -148,7 +148,7 @@ function! s:run_file(file_name)
 
         " read the macro file into the register and run it
         let l:macro_content = readfile(a:file_name,'b')
-        call setreg(g:marvim_register, l:macro_content[0])
+        call setreg(g:marvim_register, l:macro_content[0], 'c')
         silent execute 'normal @' . g:marvim_register
         return 1
 


### PR DESCRIPTION
setreg() help says: "If {options} contains no register settings, then
the default is to use character mode unless {value} ends in a <NL>"

Make sure to pass 'c' option to use character mode even when the macro
ends with '^M'.

Fixes #9